### PR TITLE
use nightly-2022-04-25 and add build-std to config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -14,5 +14,9 @@ rustflags = [
 ]
 runner = "blash --port COM4 --monitor-baud 2000000 --"
 
+
+[unstable]
+build-std = ["core"]
+
 [build]
 target = "riscv32imafc-unknown-none-elf.json"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Must be on nightly (to build core for a custom target)
 
 Run with hard float support (default custom target lives in ./cargo/config.toml):
 
-```cargo run --release -Z build-std=core```
+```cargo build --release```
 
 Run with soft float:
 
-```cargo run --release --target riscv32imac-unknown-none-elf -Z build-std=core```
+```cargo build --release --target riscv32imac-unknown-none-elf```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-04-25"


### PR DESCRIPTION
Use newest working nightly and add build-std to .cargo/config.toml